### PR TITLE
Optimizer resetting when switching to online training, minor fixes

### DIFF
--- a/jaxrl_m/agents/continuous/action_optimization.py
+++ b/jaxrl_m/agents/continuous/action_optimization.py
@@ -336,7 +336,7 @@ def action_optimization_sample_actions(
         if len(observations["state"].shape) == 1:
             observations["state"] = observations["state"][None]
 
-    repeated_critic_observations = jax.tree.map(
+    repeated_critic_observations = jax.tree_map(
         lambda x: x[:, None]
         .repeat(num_base_policy_actions, axis=1)
         .reshape(batch_size * num_base_policy_actions, *x.shape[1:]),
@@ -373,7 +373,7 @@ def action_optimization_sample_actions(
         base_policy_actions = base_policy_actions.reshape(
             batch_size, num_base_policy_actions, base_policy_actions.shape[-1]
         )
-        repeated_critic_observations = jax.tree.map(
+        repeated_critic_observations = jax.tree_map(
             lambda x: x.reshape(
                 batch_size,
                 num_base_policy_actions,
@@ -389,7 +389,7 @@ def action_optimization_sample_actions(
         # top_k_indices needs to have the same number of dimensions as repeated_observations
         # for every key. Thus, for every key, we maintain the 2 existing dimensions, and add
         # None for every other dimension.
-        repeated_critic_observations = jax.tree.map(
+        repeated_critic_observations = jax.tree_map(
             lambda x: jnp.take_along_axis(
                 x,
                 top_k_indices[
@@ -410,7 +410,7 @@ def action_optimization_sample_actions(
             batch_size * num_actions_to_keep,
             base_policy_actions.shape[-1],
         )
-        repeated_critic_observations = jax.tree.map(
+        repeated_critic_observations = jax.tree_map(
             lambda x: x.reshape(
                 batch_size * num_actions_to_keep,
                 *x.shape[2:],
@@ -574,7 +574,7 @@ def add_base_policy_actions_to_batch(
         batch[observation_key]["base_policy_actions"] = (
             base_policy_agent.sample_actions(
                 # Add empty observation history axis
-                jax.tree.map(lambda x: x[:, None], batch[observation_key]),
+                jax.tree_map(lambda x: x[:, None], batch[observation_key]),
                 repeat=num_base_policy_actions,
                 cache_dir=cache_dir,
                 timer=timer,

--- a/jaxrl_m/agents/continuous/ddpm_bc.py
+++ b/jaxrl_m/agents/continuous/ddpm_bc.py
@@ -194,7 +194,7 @@ class DDPMBCAgent(BasePolicy):
             # unbatched input from evaluation
             batch_size = 1
             need_to_unbatch = True
-            observations = jax.tree.map(lambda x: x[None], observations)
+            observations = jax.tree_map(lambda x: x[None], observations)
         else:
             batch_size = observations[obs_key].shape[0]
             need_to_unbatch = False
@@ -211,7 +211,7 @@ class DDPMBCAgent(BasePolicy):
                 "proprio": observations["proprio"],
             }
 
-        observations = jax.tree.map(
+        observations = jax.tree_map(
             lambda x: jnp.repeat(x, repeat, axis=1).reshape(
                 batch_size * repeat, 1, *x.shape[2:]
             ),
@@ -450,5 +450,5 @@ class DDPMBCAgent(BasePolicy):
 
     def to_device(self, sharding: jax.sharding.Sharding):
         self.state = jax.device_put(
-            jax.tree.map(jnp.array, self.state), sharding.replicate()
+            jax.tree_map(jnp.array, self.state), sharding.replicate()
         )

--- a/jaxrl_m/agents/continuous/diffusion_q_learning.py
+++ b/jaxrl_m/agents/continuous/diffusion_q_learning.py
@@ -45,7 +45,7 @@ class DiffusionQLearningAgent(SACAgent):
         original_batch_size = batch["actions"].shape[0]
 
         # Repeat the batch cql_n_actions times
-        batch = jax.tree.map(
+        batch = jax.tree_map(
             lambda x: jnp.repeat(x, self.config["cql_n_actions"], axis=0), batch
         )
 

--- a/jaxrl_m/agents/continuous/parl_calql.py
+++ b/jaxrl_m/agents/continuous/parl_calql.py
@@ -153,7 +153,7 @@ class PARLCalQLAgent:
             key = "proprio" if "proprio" in observations else "state"
             if len(observations[key].shape) == 1:
                 need_to_unbatch = True
-                observations = jax.tree.map(
+                observations = jax.tree_map(
                     lambda x: jnp.expand_dims(x, 0), observations
                 )
             else:
@@ -243,7 +243,7 @@ class PARLCalQLAgent:
 
     def to_device(self, sharding: jax.sharding.Sharding):
         self.state = jax.device_put(
-            jax.tree.map(jnp.array, self.state), sharding.replicate()
+            jax.tree_map(jnp.array, self.state), sharding.replicate()
         )
 
     def restore_checkpoint(self, path: str) -> "PARLCalQLAgent":

--- a/jaxrl_m/agents/continuous/parl_iql.py
+++ b/jaxrl_m/agents/continuous/parl_iql.py
@@ -132,7 +132,7 @@ class PARLIQLAgent:
             key = "proprio" if "proprio" in observations else "state"
             if len(observations[key].shape) == 1:
                 need_to_unbatch = True
-                observations = jax.tree.map(
+                observations = jax.tree_map(
                     lambda x: jnp.expand_dims(x, 0), observations
                 )
             else:
@@ -174,7 +174,7 @@ class PARLIQLAgent:
 
     def to_device(self, sharding: jax.sharding.Sharding):
         self.state = jax.device_put(
-            jax.tree.map(jnp.array, self.state), sharding.replicate()
+            jax.tree_map(jnp.array, self.state), sharding.replicate()
         )
 
     def restore_checkpoint(self, path: str) -> "PARLIQLAgent":

--- a/jaxrl_m/agents/continuous/sac.py
+++ b/jaxrl_m/agents/continuous/sac.py
@@ -55,7 +55,7 @@ class SACAgent(flax.struct.PyTreeNode):
         goal_indices = jnp.where(
             neg_goal_mask, neg_goal_indices, jnp.arange(batch_size)
         )
-        new_goals = jax.tree.map(lambda x: x[goal_indices], batch["goals"])
+        new_goals = jax.tree_map(lambda x: x[goal_indices], batch["goals"])
         new_rewards = jnp.where(neg_goal_mask, -1, batch["rewards"])
         new_masks = jnp.where(neg_goal_mask, 1, batch["masks"])
 
@@ -973,11 +973,11 @@ class SACAgent(flax.struct.PyTreeNode):
         def make_minibatch(data: jnp.ndarray):
             return jnp.reshape(data, (utd_ratio, minibatch_size) + data.shape[1:])
 
-        minibatches = jax.tree.map(make_minibatch, batch)
+        minibatches = jax.tree_map(make_minibatch, batch)
 
         (agent,), critic_infos = jax.lax.scan(scan_body, (self,), (minibatches,))
 
-        critic_infos = jax.tree.map(lambda x: jnp.mean(x, axis=0), critic_infos)
+        critic_infos = jax.tree_map(lambda x: jnp.mean(x, axis=0), critic_infos)
         del critic_infos["actor"]
         del critic_infos["temperature"]
 

--- a/jaxrl_m/common/common.py
+++ b/jaxrl_m/common/common.py
@@ -22,7 +22,7 @@ def shard_batch(batch, sharding):
         batch: A pytree of arrays.
         sharding: A jax Sharding object with shape (num_devices,).
     """
-    return jax.tree.map(
+    return jax.tree_map(
         lambda x: jax.device_put(
             x, sharding.reshape(sharding.shape[0], *((1,) * (x.ndim - 1)))
         ),
@@ -115,7 +115,7 @@ class JaxRLTrainState(struct.PyTreeNode):
 
     @staticmethod
     def _tx_tree_map(*args, **kwargs):
-        return jax.tree.map(
+        return jax.tree_map(
             *args,
             is_leaf=lambda x: isinstance(x, optax.GradientTransformation),
             **kwargs,
@@ -128,7 +128,7 @@ class JaxRLTrainState(struct.PyTreeNode):
 
             new_target_params = tau * params + (1 - tau) * target_params
         """
-        new_target_params = jax.tree.map(
+        new_target_params = jax.tree_map(
             lambda p, tp: p * tau + tp * (1 - tau), self.params, self.target_params
         )
         return self.replace(target_params=new_target_params)
@@ -158,7 +158,7 @@ class JaxRLTrainState(struct.PyTreeNode):
         )
 
         # apply all the updates additively
-        updates_acc = jax.tree.map(
+        updates_acc = jax.tree_map(
             lambda *xs: jnp.sum(jnp.array(xs), axis=0), *updates_flat
         )
         new_params = optax.apply_updates(self.params, updates_acc)
@@ -203,7 +203,7 @@ class JaxRLTrainState(struct.PyTreeNode):
         rngs = jax.tree_util.tree_unflatten(treedef, rngs)
 
         # compute gradients
-        grads_and_aux = jax.tree.map(
+        grads_and_aux = jax.tree_map(
             lambda loss_fn, rng: jax.grad(loss_fn, has_aux=has_aux)(self.params, rng),
             loss_fns,
             rngs,
@@ -218,8 +218,8 @@ class JaxRLTrainState(struct.PyTreeNode):
 
         # apply gradients
         if has_aux:
-            grads = jax.tree.map(lambda _, x: x[0], loss_fns, grads_and_aux)
-            aux = jax.tree.map(lambda _, x: x[1], loss_fns, grads_and_aux)
+            grads = jax.tree_map(lambda _, x: x[0], loss_fns, grads_and_aux)
+            aux = jax.tree_map(lambda _, x: x[1], loss_fns, grads_and_aux)
             new_train_state, updates = self.apply_gradients(grads=grads)
             # log the norm values
             grad_norm = optax.global_norm(grads)

--- a/jaxrl_m/common/evaluation.py
+++ b/jaxrl_m/common/evaluation.py
@@ -136,8 +136,8 @@ def evaluate_with_trajectories_vectorized(
         log_progress = False
         for i in range(num_envs):
             if episode_counts[i] < num_episodes // num_envs:
-                obs = jax.tree.map(lambda x: x[i], observations)
-                next_obs = jax.tree.map(lambda x: x[i], next_observations)
+                obs = jax.tree_map(lambda x: x[i], observations)
+                next_obs = jax.tree_map(lambda x: x[i], next_observations)
                 transition = dict(
                     observation=obs,
                     next_observation=next_obs,

--- a/jaxrl_m/data/replay_buffer.py
+++ b/jaxrl_m/data/replay_buffer.py
@@ -100,7 +100,7 @@ class ReplayBuffer(Dataset):
         self._size = min(self._size + batch_size, self._capacity)
 
     def save(self, path: str):
-        dict_to_save = jax.tree.map(lambda x: x[: self._size], self.dataset_dict)
+        dict_to_save = jax.tree_map(lambda x: x[: self._size], self.dataset_dict)
         path = os.path.join(path, "replay_buffer.npz")
         if tf.io.gfile.exists(path):
             tf.io.gfile.remove(path)

--- a/jaxrl_m/envs/wrappers/chunking.py
+++ b/jaxrl_m/envs/wrappers/chunking.py
@@ -9,7 +9,7 @@ import numpy as np
 
 def stack_obs(obs):
     dict_list = {k: [dic[k] for dic in obs] for k in obs[0]}
-    return jax.tree.map(
+    return jax.tree_map(
         lambda x: np.stack(x), dict_list, is_leaf=lambda x: type(x) == list
     )
 

--- a/jaxrl_m/envs/wrappers/remap.py
+++ b/jaxrl_m/envs/wrappers/remap.py
@@ -31,4 +31,4 @@ class RemapWrapper(gym.ObservationWrapper):
             raise TypeError(f"Unsupported type {type(new_structure)}")
 
     def observation(self, observation):
-        return jax.tree.map(lambda x: observation[x], self.new_structure)
+        return jax.tree_map(lambda x: observation[x], self.new_structure)

--- a/jaxrl_m/vision/bigvision_utils.py
+++ b/jaxrl_m/vision/bigvision_utils.py
@@ -107,7 +107,7 @@ def pad_shard_unpad(wrapped, static_argnums=(0,), static_argnames=()):
             # Transfer back before cutting, to reduce on-device shape diversity.
             return einops.rearrange(jax.device_get(x), "d b ... -> (d b) ...")[:b]
 
-        return jax.tree.map(unpad, out)
+        return jax.tree_map(unpad, out)
 
     return pad_shard_unpad_wrapper
 
@@ -270,10 +270,10 @@ def accumulate_gradient(loss_and_grad_fn, params, images, labels, accum_steps):
             )
             li, gi = loss_and_grad_fn(params, imgs, lbls)
             l, g = l_and_g
-            return (l + li, jax.tree.map(lambda x, y: x + y, g, gi))
+            return (l + li, jax.tree_map(lambda x, y: x + y, g, gi))
 
         l, g = jax.lax.fori_loop(1, accum_steps, acc_grad_and_loss, (l, g))
-        return jax.tree.map(lambda x: x / accum_steps, (l, g))
+        return jax.tree_map(lambda x: x / accum_steps, (l, g))
     else:
         return loss_and_grad_fn(params, images, labels)
 
@@ -474,7 +474,7 @@ def _traverse_with_names(tree, with_inner_nodes=False):
         tree = flax.serialization.to_state_dict(tree)
     # Don't output the non-leaf nodes. If the optimizer doesn't have a state
     # the tree leaves can be Nones which was interpreted as a leaf by this
-    # function but not by the other functions (like jax.tree.map).
+    # function but not by the other functions (like jax.tree_map).
     if tree is None:
         return
     elif isinstance(tree, Mapping):
@@ -524,7 +524,7 @@ def tree_flatten_with_names(tree):
 
 
 def tree_map_with_names(f, tree, *rest):
-    """Like jax.tree.map but with a filter on the leaf path name.
+    """Like jax.tree_map but with a filter on the leaf path name.
 
     Args:
       f: A function with first parameter `name` (path-like "a/b/c") and remaining
@@ -859,7 +859,7 @@ def make_mask_trees(tree, patterns, *, log=None):
 
     multimask = tree_map_with_names(matchfirst, tree)
     return [
-        jax.tree.map(lambda matches, i=idx: matches[i], multimask)
+        jax.tree_map(lambda matches, i=idx: matches[i], multimask)
         for idx in range(len(patterns))
     ]
 

--- a/jaxrl_m/vision/data_augmentations.py
+++ b/jaxrl_m/vision/data_augmentations.py
@@ -169,7 +169,7 @@ def hsv_to_rgb(h, s, v):
 
 
 def adjust_brightness(rgb_tuple, delta):
-    return jax.tree.map(lambda x: x + delta, rgb_tuple)
+    return jax.tree_map(lambda x: x + delta, rgb_tuple)
 
 
 def adjust_contrast(image, factor):
@@ -177,7 +177,7 @@ def adjust_contrast(image, factor):
         mean = jnp.mean(channel, axis=(-2, -1), keepdims=True)
         return factor * (channel - mean) + mean
 
-    return jax.tree.map(_adjust_contrast_channel, image)
+    return jax.tree_map(_adjust_contrast_channel, image)
 
 
 def adjust_saturation(h, s, v, factor):
@@ -256,7 +256,7 @@ def color_transform(
 
         def cond_fn(args, i):
             def clip(args):
-                return jax.tree.map(lambda arg: jnp.clip(arg, 0.0, 1.0), args)
+                return jax.tree_map(lambda arg: jnp.clip(arg, 0.0, 1.0), args)
 
             out = jax.lax.cond(
                 should_apply & should_apply_color & (i == idx),
@@ -275,7 +275,7 @@ def color_transform(
     random_hue_cond = _make_cond(_random_hue, idx=3)
 
     def _color_jitter(x):
-        rgb_tuple = tuple(jax.tree.map(jnp.squeeze, jnp.split(x, 3, axis=-1)))
+        rgb_tuple = tuple(jax.tree_map(jnp.squeeze, jnp.split(x, 3, axis=-1)))
         if shuffle:
             order = jax.random.permutation(perm_rng, jnp.arange(4, dtype=jnp.int32))
         else:

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -1,20 +1,20 @@
 gym == 0.23.1
-numpy < 2
-jax[tpu]==0.4.35
+numpy == 1.24.2
+jax[tpu]==0.4.24
 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 distrax==0.1.5
-flax==0.10.2
+flax==0.8.0
 ml_collections >= 0.1.0
 tqdm >= 4.60.0
-chex==0.1.87
-optax==0.2.4
-orbax-checkpoint==0.10.1
+chex==0.1.86
+optax==0.2.2
+orbax-checkpoint==0.4.4
 absl-py >= 0.12.0
 scipy >= 1.6.0
 wandb >= 0.12.14
 plotly
-tensorflow == 2.18
-tensorflow-probability[tf] == 0.25.0
+tensorflow == 2.15
+tensorflow-probability[tf] == 0.23.0
 einops >= 0.6.1
 imageio >= 2.31.1
 moviepy >= 1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 gym == 0.23.1
-numpy < 2
-jax[cuda12]==0.4.35
+numpy == 1.24.2
+jax[cuda12]==0.4.24
 distrax==0.1.5
-flax==0.10.2
+flax==0.8.0
 ml_collections >= 0.1.0
 tqdm >= 4.60.0
-chex==0.1.87
-optax==0.2.4
-orbax-checkpoint==0.10.1
+chex==0.1.86
+optax==0.2.2
+orbax-checkpoint==0.4.4
 absl-py >= 0.12.0
 scipy >= 1.6.0
 wandb >= 0.12.14
 plotly
-tensorflow == 2.18
-tensorflow-probability[tf] == 0.25.0
+tensorflow == 2.15
+tensorflow-probability[tf] == 0.23.0
 einops >= 0.6.1
 imageio >= 2.31.1
 moviepy >= 1.0.3

--- a/train.py
+++ b/train.py
@@ -144,7 +144,7 @@ def add_empty_observation_history_axis_to_batch(batch: Batch) -> Batch:
     """
     for key in ["observations", "next_observations", "actions"]:
         # First dimension is batch size, second dimension is chunking dimension
-        batch[key] = jax.tree.map(lambda x: x[:, None], batch[key])
+        batch[key] = jax.tree_map(lambda x: x[:, None], batch[key])
     return batch
 
 
@@ -159,7 +159,7 @@ def unbatch_observation_history_axis(batch: Batch) -> Batch:
         Batch without observation history axis.
     """
     for key in ["observations", "next_observations", "actions"]:
-        batch[key] = jax.tree.map(lambda x: x[:, 0], batch[key])
+        batch[key] = jax.tree_map(lambda x: x[:, 0], batch[key])
     return batch
 
 
@@ -360,9 +360,9 @@ def get_policy_fn(
             # Get samples from the base policy, put them in the observation dict
 
             if obs_ndim == 2:
-                batched_observations = jax.tree.map(lambda x: x[:, None], observations)
+                batched_observations = jax.tree_map(lambda x: x[:, None], observations)
             elif obs_ndim == 1:
-                batched_observations = jax.tree.map(
+                batched_observations = jax.tree_map(
                     lambda x: x[None, None], observations
                 )
             observations["base_policy_actions"] = base_policy.sample_actions(
@@ -376,9 +376,9 @@ def get_policy_fn(
         if "ddpm" in FLAGS.config.agent:
 
             if obs_ndim == 2:
-                observations = jax.tree.map(lambda x: x[:, None], observations)
+                observations = jax.tree_map(lambda x: x[:, None], observations)
             elif obs_ndim == 1:
-                observations = jax.tree.map(lambda x: x[None, None], observations)
+                observations = jax.tree_map(lambda x: x[None, None], observations)
         actions = jax.device_get(
             agent.sample_actions(
                 observations, *args, **kwargs, argmax=argmax, timer=timer
@@ -827,7 +827,7 @@ def train_agent(_):
     # The transformer agent handles this internally.
     # if not is_transformer_agent:
     # need the jnp.array to avoid a bug where device_put doesn't recognize primitives
-    # agent = jax.device_put(jax.tree.map(jnp.array, agent), sharding.replicate())
+    # agent = jax.device_put(jax.tree_map(jnp.array, agent), sharding.replicate())
     # agent = jax.device_put(agent, sharding.replicate())
     agent.to_device(sharding)
     if base_policy_agent is not None:
@@ -1278,17 +1278,17 @@ def train_agent(_):
                 if hasattr(agent, "forward_critic"):
                     timer.tick("q-mc calculation")
                     initial_states = [t["observation"][0] for t in trajectories]
-                    initial_states = jax.tree.map(
+                    initial_states = jax.tree_map(
                         lambda *x: jnp.stack(x), *initial_states
                     )
                     initial_actions = [t["action"][0] for t in trajectories]
-                    initial_actions = jax.tree.map(
+                    initial_actions = jax.tree_map(
                         lambda *x: jnp.stack(x), *initial_actions
                     )
                     initial_qs = agent.forward_critic(
                         initial_states, initial_actions, rng=None, train=False
                     ).mean(axis=0)
-                    mc_returns = jax.tree.map(
+                    mc_returns = jax.tree_map(
                         lambda t: calc_return_to_go(
                             rewards=np.array(t["reward"]) * FLAGS.reward_scale
                             + FLAGS.reward_bias,
@@ -1303,7 +1303,7 @@ def train_agent(_):
                             x, dict
                         ),  # only map over traj in trajs
                     )
-                    initial_mc_returns = jax.tree.map(lambda t: t[0], mc_returns)
+                    initial_mc_returns = jax.tree_map(lambda t: t[0], mc_returns)
 
                     timer.tock("q-mc calculation")
                     timer.tick("q_values_over_trajectory")


### PR DESCRIPTION
Summary of changes:

- When switching to online fine-tuning, reset the optimizer state. We only need to reset the Critic optimizer state, since no policy distillation updates are done offline. This should slightly alleviate the offline-to-online drop in performance.
- If the offline dataset size is known (only for D4RL tasks), the policy distillation batches will treat offline and online samples the same instead of using a fix mixing ratio.
- Downgrade Jax and related dependencies.

These changes are made to match the code used for the paper experiments.